### PR TITLE
Added missing equals sign after template_args

### DIFF
--- a/bin/vagueant
+++ b/bin/vagueant
@@ -129,7 +129,7 @@ command_init() {
 # template=ubuntu
 
 # Some templates will accept additional arguments, pass in some:
-# template_args(--arch i386 --release precise)
+# template_args=(--arch i386 --release precise)
 
 # Provisioning enables you to run perform installations or configuration
 # once the base lxc has been installed.


### PR DESCRIPTION
I uncommented the template_args options and ran 'vagueant up' but got syntax error near unexpected token `--arch'

Added equals sign to fix it.
