### PR TITLE
Print usage when no command is given to vagueant

### DIFF
--- a/bin/vagueant
+++ b/bin/vagueant
@@ -377,6 +377,11 @@ while true; do
 	shift
 done
 
+# Show usage if no command is entered
+if [[ "$command" == '' ]]; then
+	usage
+fi
+
 # Check if the command actually exists
 if [[ "$(type -t "command_$command")" != 'function' ]]; then
 	usage "unknown command '$command'"


### PR DESCRIPTION
When running vagueant without a command it prints an error message and usage. Added a snippet so it only prints usage.
